### PR TITLE
Allows multiple e-mail recipients, split by comma or semicolon

### DIFF
--- a/imports/api/email/send-report-email.jsx
+++ b/imports/api/email/send-report-email.jsx
@@ -21,7 +21,7 @@ const sendReportEmail = ({
       : ''}`,
   );
 
-  const recipientEmails = [userReportsEmail];
+  const recipientEmails = userReportsEmail.split(/, *|; */);
   if (sendCopyToUser && userEmail !== userReportsEmail) {
     recipientEmails.push(userEmail);
   }


### PR DESCRIPTION
- it was already possible to save several values split, however only the
first was sent. Splits the string to add all recipients into the list

Signed-off-by: João Scalett <joao.scalett@gmail.com>